### PR TITLE
:bug: Fix converting dict having integer keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Version 2.1.0
 * Changes:
   * Handling bool values properly
   * Support for disabling default list folding
+  * Fix converting dict having integer as key
   * Add /docs
 
 Version 2.0.0

--- a/dicttoxml2/utils.py
+++ b/dicttoxml2/utils.py
@@ -84,7 +84,7 @@ def make_valid_xml_name(key: str, attr: Dict[str, str]):
         return key, attr
 
     # prepend a lowercase n if the key is numeric
-    if key.isdigit():
+    if isinstance(key, int) or key.isdigit():
         return 'n%s' % (key), attr
 
     # replace spaces with underscores if that fixes the problem

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,3 +77,9 @@ def test_folding_list_ignored() -> None:
     payload: dict = {'book': [{'title': 'Python Programming', 'license': 'GPL', 'author': ['Adam', 'Benny', 'Charlie']}, {'license': 'Apache 2.0', 'title': 'Business Modelling'}]}
 
     assert dicttoxml(payload, fold_list=False, attr_type=False) == b'<?xml version="1.0" encoding="UTF-8" ?><root><book><title>Python Programming</title><license>GPL</license><author>Adam</author><author>Benny</author><author>Charlie</author></book><book><license>Apache 2.0</license><title>Business Modelling</title></book></root>'
+
+
+def test_fix_dict_integer_key() -> None:
+    payload: dict = {1: "abc"}
+
+    assert dicttoxml(payload) == b'<?xml version="1.0" encoding="UTF-8" ?><root><n1 type="str">abc</n1></root>'


### PR DESCRIPTION
Taken from https://github.com/quandyfactory/dicttoxml/pull/62